### PR TITLE
Misc small fixes

### DIFF
--- a/Algorithm.cpp
+++ b/Algorithm.cpp
@@ -57,6 +57,7 @@ Algorithm::Algorithm(const Algorithm& a)
 	useNODELIMIT = a.useNODELIMIT;
 	useTIMELIMIT = a.useTIMELIMIT;
 	useTHREADS = a.useTHREADS;
+	useAFTERSTATES = a.useAFTERSTATES;
 	SEARCHDEPTHLIMIT = a.SEARCHDEPTHLIMIT;
 	startDepth = a.startDepth;
 	SEARCHTIMELIMIT = a.SEARCHTIMELIMIT;

--- a/UCT.h
+++ b/UCT.h
@@ -12,7 +12,6 @@
 
 #include "Algorithm.h"
 #include "algorithmStates.h"
-#include <ext/hash_map>
 
 class UCTNode {
 public:


### PR DESCRIPTION
ext/hash_map is no longer used and can be removed.

I'm not sure if omitting useAFTERSTATES from the Algorithm copy constructor was intended, but it is causing an error in Valgrind.